### PR TITLE
use `bin-wrapper` to download and test atom-shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
-*.zip
 dist

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you require `atom-shell` inside your node app it will return the file path to
 Use this to spawn atom shell
 
 ``` js
-var atom = require('atom-shell')
+var atom = require('atom-shell').path
 var proc = require('child_process')
 
 // will something similar to print /Users/maf/.../Atom

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+var spawn = require('child_process').spawn;
+
+spawn(require('./').path, process.argv.slice(2), { stdio: 'inherit' })
+  .on('exit', process.exit);

--- a/index.js
+++ b/index.js
@@ -1,3 +1,26 @@
-var fs = require('fs')
-var path = require('path')
-module.exports = fs.readFileSync(path.join(__dirname, 'run.bat'), 'utf-8').slice(1,-1)
+var BinWrapper = require('bin-wrapper');
+var path = require('path');
+
+var BIN;
+var BIN_VERSION = '0.18.1';
+var BASE_URL = [
+  'https://github.com/atom/atom-shell/releases/download/v',
+  BIN_VERSION + '/atom-shell-v' + BIN_VERSION
+].join('');
+
+if (process.platform === 'win32') BIN = 'atom.exe';
+else if (process.platform === 'darwin') BIN = 'Atom.app/Contents/MacOS/Atom';
+else BIN = 'atom';
+
+var bin = new BinWrapper({strip: 0})
+  .src(BASE_URL + '-darwin-x64.zip', 'darwin')
+  .src(BASE_URL + '-linux-ia32.zip', 'linux', 'x86')
+  .src(BASE_URL + '-linux-x64.zip', 'linux', 'x64')
+  .src(BASE_URL + '-win32-ia32.zip', 'win32')
+  .dest(path.join(__dirname, 'dist'))
+  .use(BIN)
+  .version(BIN_VERSION);
+
+module.exports.bin = bin;
+module.exports.path = bin.path();
+module.exports.version = BIN_VERSION;

--- a/install.js
+++ b/install.js
@@ -1,33 +1,10 @@
-#!/usr/bin/env node
+var bin = require('./').bin;
 
-var os = require('os')
-var path = require('path')
-var nugget = require('nugget')
-var extract = require('extract-zip')
-var fs = require('fs')
+bin.run(['--version'], function (err) {
+  if (err) {
+    console.log(err);
+    return;
+  }
 
-var platform = os.platform()
-var arch = os.arch()
-var version = '0.18.0'
-var name = 'atom-shell-v'+version+'-'+platform+'-'+arch+'.zip'
-var url = 'https://github.com/atom/atom-shell/releases/download/v'+version+'/atom-shell-v'+version+'-'+platform+'-'+arch+'.zip'
-
-var onerror = function(err) {
-  throw err
-}
-
-var paths = {
-  darwin: path.join(__dirname, './dist/Atom.app/Contents/MacOS/Atom'),
-  linux: path.join(__dirname, './dist/atom'),
-  win32: path.join(__dirname, './dist/atom.exe')
-}
-
-if (!paths[platform]) throw new Error('Unknown platform: '+platform)
-
-nugget(url, {target:name, dir:__dirname, resume:true}, function(err) {
-  if (err) return onerror(err)
-  fs.writeFileSync(path.join(__dirname, 'run.bat'), '"'+paths[platform]+'"')
-  extract(path.join(__dirname, name), {dir:path.join(__dirname, 'dist')}, function(err) {
-    if (err) return onerror(err)
-  })
-})
+  console.log('atom-shell downloaded successfully!');
+});

--- a/package.json
+++ b/package.json
@@ -11,12 +11,11 @@
     "test": "tape test/*.js"
   },
   "bin": {
-    "atom-shell": "run.bat"
+    "atom-shell": "cli.js"
   },
   "main": "index.js",
   "dependencies": {
-    "extract-zip": "^1.0.3",
-    "nugget": "^1.1.2"
+    "bin-wrapper": "^2.0.1"
   },
   "devDependencies": {
     "tape": "^3.0.1"

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
 var tape = require('tape')
-var atom = require('../')
+var atom = require('../').path;
 var fs = require('fs')
 
 tape('has binary', function(t) {


### PR DESCRIPTION
This is a little cleaner way to wrap an executable. It will download the file and then run it with `--version` to confirm that it works and doesn't exit with anything other than `0`.