### PR TITLE
version 0.25.2

### DIFF
--- a/install.js
+++ b/install.js
@@ -8,7 +8,7 @@ var fs = require('fs')
 
 var platform = os.platform()
 var arch = os.arch()
-var version = '0.25.1'
+var version = '0.25.2'
 var filename = 'electron-v' + version + '-' + platform + '-' + arch + '.zip'
 var url = 'https://github.com/atom/electron/releases/download/v' + version + '/electron-v' + version + '-' + platform + '-' + arch + '.zip'
 


### PR DESCRIPTION
We must pick this up from the repo itself, we could use ` /repos/:owner/:repo/releases/latest` from the github API.