### PR TITLE
Fix Cache Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Download and install the latest build of electron for your OS and add it to your
 npm install electron-prebuilt --save-dev
 ```
 
-This is the preferred way to use electron, as it doesn't require users to install electron globally.
+This is the preferred way to use electron, as it doesn't require users to install electron globally. Zip files are cached locally in the home directory inside `.electron`.
 
 You can also use the `-g` flag (global) to symlink it into your PATH:
 

--- a/install.js
+++ b/install.js
@@ -33,20 +33,22 @@ if (!paths[platform]) throw new Error('Unknown platform: ' + platform)
 
 // use cache if possible
 if (pathExists.sync(path.join(cache, filename))) {
-  extractFile()
+  getFile()
 } else {
   mkdir(cache, function(err) {
     if (err) return onerror(err)
-    nugget(url, {target: filename, dir: cache, resume: true, verbose: true}, extractFile)
+    getFile()
   })
 }
 
-function extractFile (err) {
-  if (err) return onerror(err)
-  fs.writeFileSync(path.join(__dirname, 'path.txt'), paths[platform])
-  extract(path.join(cache, filename), {dir: path.join(__dirname, 'dist')}, function (err) {
-    if (err) {
-      return onerror(err)
-    }
+function getFile () {
+  nugget(url, {target: filename, dir: cache, resume: true, verbose: true}, function(err) {
+    if (err) return onerror(err)
+    fs.writeFileSync(path.join(__dirname, 'path.txt'), paths[platform])
+    extract(path.join(cache, filename), {dir: path.join(__dirname, 'dist')}, function (err) {
+      if (err) {
+        return onerror(err)
+      }
+    })
   })
 }

--- a/install.js
+++ b/install.js
@@ -7,16 +7,13 @@ var mkdir = require('mkdirp')
 var nugget = require('nugget')
 var extract = require('extract-zip')
 var fs = require('fs')
+var rimraf = require('rimraf')
 var getHomePath = require('home-path')()
 var platform = os.platform()
 var arch = os.arch()
 var version = '0.25.3'
 var filename = 'electron-v' + version + '-' + platform + '-' + arch + '.zip'
 var url = 'https://github.com/atom/electron/releases/download/v' + version + '/electron-v' + version + '-' + platform + '-' + arch + '.zip'
-
-function onerror (err) {
-  throw err
-}
 
 var paths = {
   darwin: path.join(__dirname, './dist/Electron.app/Contents/MacOS/Electron'),
@@ -25,6 +22,12 @@ var paths = {
 }
 
 var cache = path.join(getHomePath, './.electron')
+
+function onerror (err) {
+  // delete cache if any error occurs
+  rimraf.sync(cache);
+  throw err
+}
 
 if (!paths[platform]) throw new Error('Unknown platform: ' + platform)
 
@@ -42,6 +45,8 @@ function extractFile (err) {
   if (err) return onerror(err)
   fs.writeFileSync(path.join(__dirname, 'path.txt'), paths[platform])
   extract(path.join(cache, filename), {dir: path.join(__dirname, 'dist')}, function (err) {
-    if (err) return onerror(err)
+    if (err) {
+      return onerror(err)
+    }
   })
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "rimraf": "^2.3.3"
   },
   "devDependencies": {
-    "rimraf": "^2.3.3",
     "tape": "^3.0.1"
   },
   "author": "Mathias Buus",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "home-path": "^0.1.1",
     "mkdirp": "^0.5.0",
     "nugget": "^1.2.0",
-    "path-exists": "^1.0.0"
+    "path-exists": "^1.0.0",
+    "rimraf": "^2.3.3"
   },
   "devDependencies": {
     "rimraf": "^2.3.3",


### PR DESCRIPTION
Delete cache if error occurs, invokes `nugget` regardless of cache now.

rimraf is sync to make sure the cache is deleted before `err` is `throw`, I'm not sure if this is necessary behavior?

~~Ideal behavior would be to restart the download but i don't want to risk an infinite loop, this is just a quick / dirty fix.~~ `nugget` automatically restarts downloaded 
