### PR TITLE
Allow configuration of electron version in client package

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,11 @@ console.log(electron)
 // spawn electron
 var child = proc.spawn(electron)
 ```
+
+`electron-prebuild` will respect any configuration found with [`rc`](https://github.com/dominictarr/rc) so if you want to require a specify version in your module you can create a file named `.electron-prebuildrc` with this content:
+
+```json
+{
+  "version" : "0.27.2"
+}
+```

--- a/index.js
+++ b/index.js
@@ -1,4 +1,16 @@
-var fs = require('fs')
-var path = require('path')
+var os = require('os');
+var path = require('path');
 
-module.exports = fs.readFileSync(path.join(__dirname, 'path.txt'), 'utf-8')
+var paths = {
+  darwin: path.join(__dirname, './dist/Electron.app/Contents/MacOS/Electron'),
+  linux: path.join(__dirname, './dist/electron'),
+  win32: path.join(__dirname, './dist/electron.exe')
+};
+
+var electronPath = function(){
+  var platform = os.platform();
+  if (!paths[platform]) throw new Error('Unknown platform: ' + platform);
+  return paths[platform];
+};
+
+module.exports = electronPath();

--- a/install.js
+++ b/install.js
@@ -1,38 +1,30 @@
 #!/usr/bin/env node
 
 // maintainer note - update this manually when doing new releases:
-var version = '0.27.2'
 
-var fs = require('fs')
-var os = require('os')
-var path = require('path')
-var extract = require('extract-zip')
-var download = require('electron-download')
+var fs = require('fs');
+var path = require('path');
 
-var platform = os.platform()
+var extract = require('extract-zip');
+var download = require('electron-download');
+
+// default config
+var config = { version : '0.27.3' };
+
+// Try to load a custom electron config
+try { version = require('rc')('electron-prebuild', config); } catch (e) { }
 
 function onerror (err) {
-  throw err
+  throw err;
 }
-
-var paths = {
-  darwin: path.join(__dirname, './dist/Electron.app/Contents/MacOS/Electron'),
-  linux: path.join(__dirname, './dist/electron'),
-  win32: path.join(__dirname, './dist/electron.exe')
-}
-
-if (!paths[platform]) throw new Error('Unknown platform: ' + platform)
 
 // downloads if not cached
-download({version: version}, extractFile)
+download(config, extractFile);
 
 // unzips and makes path.txt point at the correct executable
 function extractFile (err, zipPath) {
-  if (err) return onerror(err)
-  fs.writeFile(path.join(__dirname, 'path.txt'), paths[platform], function (err) {
-    if (err) return onerror(err)
-    extract(zipPath, {dir: path.join(__dirname, 'dist')}, function (err) {
-      if (err) return onerror(err)
-    })
-  })
+  if (err) return onerror(err);
+  extract(zipPath, {dir: path.join(__dirname, 'dist')}, function (err) {
+    if (err) return onerror(err);
+  });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-prebuilt",
-  "version": "0.27.2",
+  "version": "0.27.3",
   "description": "Install electron (formerly called atom-shell) prebuilts using npm",
   "repository": {
     "type": "git",
@@ -17,8 +17,9 @@
   },
   "main": "index.js",
   "dependencies": {
+    "electron-download": "^1.0.0",
     "extract-zip": "^1.0.3",
-    "electron-download": "^1.0.0"
+    "rc": "^1.0.3"
   },
   "devDependencies": {
     "home-path": "^0.1.1",


### PR DESCRIPTION
This PR includes the following.

  * Upgrade to `electron@0.27.3`
  * No longer create a `path.txt` just resolve the path on `require`. (better portability)
  * Use [`rc`](https://github.com/dominictarr/rc) to make it possible to require a custom version of electron
  * documentation

The gist of this is that a client package can create a file `.electron-prebuildrc` like 
```json
{
  "version" : "0.27.0"
}
```

and `electron-prebuild` will than install that exact version. In fact, the whole configuration is 1:1 passed to [`electron-download`](https://github.com/maxogden/electron-download).
