### PR TITLE
use version from package.json

### DIFF
--- a/install.js
+++ b/install.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-// maintainer note - update this manually when doing new releases:
-var version = '0.27.3'
+// maintainer note - x.y.z-ab version in package.json -> x.y.z
+var version = require('./package').version.replace(/-.*/, '')
 
 var fs = require('fs')
 var os = require('os')


### PR DESCRIPTION
Can't we just use the version directly from `package.json` or am I missing something?