### PR TITLE
Relay electron exit code

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -4,4 +4,7 @@ var electron = require('./')
 
 var proc = require('child_process')
 
-proc.spawn(electron, process.argv.slice(2), {stdio: 'inherit'});
+var child = proc.spawn(electron, process.argv.slice(2), {stdio: 'inherit'});
+child.on('close', function (code) {
+  process.exit(code);
+})


### PR DESCRIPTION
**TL;DR: The current `cli.js` wrapper always exits with `0`, no matter what electron actually exits with. This PR fixes that.**

Real-life example: some applications (like electron itself) have an interesting test setup:

  * electron is launched, from which
  * ...a BrowserWindow is created, in which
  * ...some javascript is loaded (e.g. mocha + a bunch of specs)
  * The test results (number of tests failed, for instance) are [sent by ipc](https://github.com/atom/electron/blob/399f47ef0f0017a1ad52fab2399b1e1ef5103e29/spec/static/index.html#L73) back to the nodejs side
  * ...where [`process.exit()` is called](https://github.com/atom/electron/blob/399f47ef0f0017a1ad52fab2399b1e1ef5103e29/spec/static/main.js#L24) so that test failures result in a non-zero exit code
  * which is useful when running on [Travis CI](https://travis-ci.org/) by example.

Now, [atom/electron](https://travis-ci.org/atom/electron) isn't touched by this, since they also build a fresh copy of electron right there on the Travis CI instance so I'm assuming they run the binary directly.

However, if anyone wants to use `electron-prebuilt` to run tests on Travis CI via the same method, they won't be able to detect failures, as [this build](https://travis-ci.org/itchio/itchio-app/builds/83977004#L519) demonstrates (It should definitely fail).

This PR fixes that in what I'm hoping is the least possible amount of changes, and I can't think of a way it would break electron-prebuilt for anyone else. Let me know, though!