### PR TITLE
Don't save __dirname into path.txt.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 var fs = require('fs')
 var path = require('path')
 
-module.exports = fs.readFileSync(path.join(__dirname, 'path.txt'), 'utf-8')
+module.exports = path.join(__dirname, fs.readFileSync(path.join(__dirname, 'path.txt'), 'utf-8'))

--- a/install.js
+++ b/install.js
@@ -23,14 +23,14 @@ function onerror (err) {
 }
 
 var paths = {
-  darwin: path.join(__dirname, './dist/Electron.app/Contents/MacOS/Electron'),
-  linux: path.join(__dirname, './dist/electron'),
-  win32: path.join(__dirname, './dist/electron.exe')
+  darwin: 'dist/Electron.app/Contents/MacOS/Electron',
+  linux: 'dist/electron',
+  win32: 'dist/electron.exe'
 }
 
 if (!paths[platform]) throw new Error('Unknown platform: ' + platform)
 
-if (installedVersion === version && fs.existsSync(paths[platform])) {
+if (installedVersion === version && fs.existsSync(path.join(__dirname, paths[platform]))) {
   process.exit(0)
 }
 


### PR DESCRIPTION
Allows install to work even if our directory is moved later.