### PR TITLE
Allow specifying StrictSSL in the NPM config file

### DIFF
--- a/install.js
+++ b/install.js
@@ -36,7 +36,7 @@ if (installedVersion === version && fs.existsSync(path.join(__dirname, paths[pla
 }
 
 // downloads if not cached
-download({version: version, arch: process.env.npm_config_arch}, extractFile)
+download({version: version, arch: process.env.npm_config_arch, strictSSL: process.env.npm_config_strict_ssl}, extractFile)
 
 // unzips and makes path.txt point at the correct executable
 function extractFile (err, zipPath) {


### PR DESCRIPTION
The standard way of specifying whether you want strict-ssl or not
is to add an entry into your npm config file for strict-ssl. Use
that entry (which is passed to the install.js as an environment
variable) to set the option for strictSSL in electron-download.